### PR TITLE
Add orchestration pipeline for staging and normalization

### DIFF
--- a/app/ingest_excel.py
+++ b/app/ingest_excel.py
@@ -122,23 +122,15 @@ def load_csv_into_staging(
     ordered_columns = schema["order"]
 
     header, has_data_rows = _read_csv_header(csv_path)
-    if header[: len(ordered_columns)] != ordered_columns:
+    if header != ordered_columns:
         raise ValueError(
             "CSV header does not match expected column order"
-            f" for table {table_name}: {header!r} does not begin with {ordered_columns!r}"
+            f" for table {table_name}: {header!r} != {ordered_columns!r}"
         )
     if not has_data_rows:
         raise ValueError("CSV contains no data rows to load")
 
-    column_targets: list[str]
-    if len(header) > len(ordered_columns):
-        extra_count = len(header) - len(ordered_columns)
-        column_targets = [f"`{column}`" for column in ordered_columns]
-        column_targets.extend(f"@unused_{index}" for index in range(extra_count))
-    else:
-        column_targets = [f"`{column}`" for column in ordered_columns]
-
-    column_list = ", ".join(column_targets)
+    column_list = ", ".join(f"`{column}`" for column in ordered_columns)
     load_sql = (
         f"LOAD DATA LOCAL INFILE %s INTO TABLE `{table_name}` "
         "FIELDS TERMINATED BY ',' ENCLOSED BY '\"' "

--- a/app/normalize_staging.py
+++ b/app/normalize_staging.py
@@ -235,7 +235,8 @@ def mark_staging_rows_processed(
     sql = (
         f"UPDATE `{staging_table}` "
         "SET processed_at = %s "
-        "WHERE file_hash = %s AND processed_at IS NULL"
+        "WHERE file_hash = %s "
+        "AND (processed_at IS NULL OR processed_at = '0000-00-00 00:00:00')"
     )
     params = (processed_at, file_hash)
 

--- a/app/normalize_staging.py
+++ b/app/normalize_staging.py
@@ -215,6 +215,7 @@ def ensure_normalized_schema(
     connection,
     table: str,
     column_mappings: Mapping[str, str],
+    column_types: Mapping[str, str] | None = None,
 ) -> bool:
     """Ensure the normalized table contains columns for every mapping key."""
 
@@ -228,7 +229,15 @@ def ensure_normalized_schema(
             continue
         if column in existing_columns:
             continue
-        column_type = _COLUMN_TYPE_OVERRIDES.get(column, "VARCHAR(255) NULL")
+        column_type = None
+        if column_types:
+            column_type = column_types.get(column)
+            if column_type is not None:
+                column_type = str(column_type).strip()
+        if not column_type:
+            column_type = _COLUMN_TYPE_OVERRIDES.get(column)
+        if not column_type:
+            column_type = "VARCHAR(255) NULL"
         additions.append((column, column_type))
 
     if not additions:

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -1,0 +1,183 @@
+"""End-to-end orchestration for preparing, staging, and normalizing uploads."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Mapping
+
+import pymysql
+
+from app import ingest_excel, normalize_staging, prep_excel
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """Structured details about a completed (or skipped) pipeline run."""
+
+    file_hash: str | None
+    staging_table: str | None
+    normalized_table: str | None
+    staged_rows: int
+    normalized_rows: int
+    batch_id: str | None
+    ingested_at: datetime | None
+    processed_at: datetime | None
+    skipped: bool = False
+
+
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workbook", help="Path to the Excel workbook to ingest")
+    parser.add_argument(
+        "sheet",
+        nargs="?",
+        default=prep_excel.DEFAULT_SHEET,
+        help="Worksheet name inside the workbook (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--source-year",
+        required=True,
+        help="Source year associated with the uploaded data",
+    )
+    parser.add_argument(
+        "--batch-id",
+        help="Optional batch identifier to associate with the upload",
+    )
+    return parser.parse_args(argv)
+
+
+def _fetch_staging_rows(connection, table: str, file_hash: str):
+    with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+        cursor.execute(
+            f"SELECT * FROM `{table}` WHERE file_hash = %s AND processed_at IS NULL",
+            (file_hash,),
+        )
+        return cursor.fetchall()
+
+
+def run_pipeline(
+    workbook_path: str,
+    sheet: str = prep_excel.DEFAULT_SHEET,
+    *,
+    source_year: str,
+    batch_id: str | None = None,
+    db_settings: Mapping[str, object] | None = None,
+) -> PipelineResult:
+    csv_path, file_hash = prep_excel.main(
+        workbook_path,
+        sheet,
+        emit_stdout=False,
+        db_settings=db_settings,
+    )
+
+    if csv_path is None:
+        LOGGER.info(
+            "Skipping pipeline for %s; duplicate hash %s", workbook_path, file_hash
+        )
+        return PipelineResult(
+            file_hash=file_hash,
+            staging_table=None,
+            normalized_table=None,
+            staged_rows=0,
+            normalized_rows=0,
+            batch_id=batch_id,
+            ingested_at=None,
+            processed_at=None,
+            skipped=True,
+        )
+
+    staging_result = ingest_excel.load_csv_into_staging(
+        csv_path,
+        sheet=sheet,
+        source_year=source_year,
+        file_hash=file_hash,
+        batch_id=batch_id,
+        db_settings=db_settings,
+    )
+
+    table_config = prep_excel._get_table_config(sheet, db_settings=db_settings)
+    staging_table = table_config["table"]
+    normalized_table = table_config.get("normalized_table")
+    if not normalized_table:
+        raise ValueError(
+            f"Sheet {sheet!r} is missing a normalized_table configuration"
+        )
+    column_mappings = table_config.get("column_mappings") or {}
+
+    settings = ingest_excel._get_db_settings(db_settings)
+    connection = pymysql.connect(**settings)
+    try:
+        connection.begin()
+        staging_rows = _fetch_staging_rows(connection, staging_table, file_hash)
+        normalized_rows = normalize_staging.insert_normalized_rows(
+            connection,
+            normalized_table,
+            staging_rows,
+            column_mappings,
+        )
+        processed_at = normalize_staging.mark_staging_rows_processed(
+            connection,
+            staging_table,
+            [row["id"] for row in staging_rows],
+            file_hash=file_hash,
+        )
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+    return PipelineResult(
+        file_hash=file_hash,
+        staging_table=staging_table,
+        normalized_table=normalized_table,
+        staged_rows=staging_result.rowcount,
+        normalized_rows=normalized_rows,
+        batch_id=staging_result.batch_id,
+        ingested_at=staging_result.ingested_at,
+        processed_at=processed_at,
+    )
+
+
+def cli(argv: Iterable[str] | None = None) -> PipelineResult:
+    args = _parse_args(argv)
+    try:
+        result = run_pipeline(
+            args.workbook,
+            args.sheet,
+            source_year=args.source_year,
+            batch_id=args.batch_id,
+        )
+    except Exception as exc:  # pragma: no cover - exercised via CLI integration
+        print(f"Pipeline failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    if result.skipped:
+        print(
+            f"Skipped ingest; duplicate file hash {result.file_hash} already processed."
+        )
+    else:
+        print(
+            "Staged {rows} rows into {staging} and normalized {normalized} rows into {normalized_table}. "
+            "file_hash={hash} batch_id={batch}"
+            .format(
+                rows=result.staged_rows,
+                staging=result.staging_table,
+                normalized=result.normalized_rows,
+                normalized_table=result.normalized_table,
+                hash=result.file_hash,
+                batch=result.batch_id,
+            )
+        )
+    return result
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via manual CLI usage
+    cli()

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -114,6 +114,7 @@ def run_pipeline(
     column_mappings = table_config.get("column_mappings")
     if not column_mappings:
         column_mappings = None
+    column_types = table_config.get("column_types") or {}
 
     settings = ingest_excel._get_db_settings(db_settings)
     connection = pymysql.connect(**settings)
@@ -123,7 +124,7 @@ def run_pipeline(
             staging_rows, column_mappings
         )
         normalize_staging.ensure_normalized_schema(
-            connection, normalized_table, resolved_mappings
+            connection, normalized_table, resolved_mappings, column_types
         )
 
         connection.begin()

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -108,7 +108,9 @@ def run_pipeline(
         raise ValueError(
             f"Sheet {sheet!r} is missing a normalized_table configuration"
         )
-    column_mappings = table_config.get("column_mappings") or {}
+    column_mappings = table_config.get("column_mappings")
+    if not column_mappings:
+        column_mappings = None
 
     settings = ingest_excel._get_db_settings(db_settings)
     connection = pymysql.connect(**settings)

--- a/app/pipeline.py
+++ b/app/pipeline.py
@@ -55,7 +55,10 @@ def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
 def _fetch_staging_rows(connection, table: str, file_hash: str):
     with connection.cursor(pymysql.cursors.DictCursor) as cursor:
         cursor.execute(
-            f"SELECT * FROM `{table}` WHERE file_hash = %s AND processed_at IS NULL",
+            (
+                "SELECT * FROM `{table}` WHERE file_hash = %s "
+                "AND (processed_at IS NULL OR processed_at = '0000-00-00 00:00:00')"
+            ).format(table=table),
             (file_hash,),
         )
         return cursor.fetchall()

--- a/app/prep_excel.py
+++ b/app/prep_excel.py
@@ -142,7 +142,17 @@ def _parse_sheet_config_rows(rows: Sequence[Mapping[str, object]]) -> dict[str, 
         normalized_table = row.get("normalized_table")
         if normalized_table is None and isinstance(options, Mapping):
             normalized_table = options.get("normalized_table")
-        config[row["sheet_name"]] = {
+        sheet_name = row["sheet_name"]
+        existing = config.get(sheet_name)
+        if (
+            existing is not None
+            and existing.get("normalized_table") is not None
+            and normalized_table is None
+        ):
+            # Preserve workbook-specific configuration that already defines the
+            # normalization target when a more generic row lacks it.
+            continue
+        config[sheet_name] = {
             "table": row["staging_table"],
             "metadata_columns": frozenset(metadata_columns),
             "required_columns": frozenset(required_columns),

--- a/app/prep_excel.py
+++ b/app/prep_excel.py
@@ -163,7 +163,7 @@ def _load_sheet_config(connection) -> dict[str, dict[str, object]]:
                   FROM {CONFIG_TABLE}
                 """
             )
-        except pymysql.err.ProgrammingError as exc:
+        except pymysql.err.MySQLError as exc:
             error_code = exc.args[0] if exc.args else None
             if error_code != 1054:
                 raise

--- a/app/prep_excel.py
+++ b/app/prep_excel.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import hashlib
+import warnings
 
 from functools import lru_cache
 from typing import Iterable, Mapping, Sequence
@@ -345,7 +346,14 @@ def main(
         file has already been processed (duplicate hash).
     """
 
-    df = pd.read_excel(xlsx_path, sheet_name=sheet, dtype=str)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Workbook contains no default style, apply openpyxl's default",
+            category=UserWarning,
+            module="openpyxl.styles.stylesheet",
+        )
+        df = pd.read_excel(xlsx_path, sheet_name=sheet, dtype=str)
 
     config = _get_table_config(
         sheet, connection=connection, db_settings=db_settings

--- a/app/prep_excel.py
+++ b/app/prep_excel.py
@@ -139,12 +139,16 @@ def _parse_sheet_config_rows(rows: Sequence[Mapping[str, object]]) -> dict[str, 
         required_columns = _loads_json(row.get("required_columns")) or []
         options = _loads_json(row.get("options")) or {}
         column_mappings = _loads_json(row.get("column_mappings"))
+        normalized_table = row.get("normalized_table")
+        if normalized_table is None and isinstance(options, Mapping):
+            normalized_table = options.get("normalized_table")
         config[row["sheet_name"]] = {
             "table": row["staging_table"],
             "metadata_columns": frozenset(metadata_columns),
             "required_columns": frozenset(required_columns),
             "options": options,
             "column_mappings": column_mappings,
+            "normalized_table": normalized_table,
         }
     return config
 

--- a/sql/migrations/20241010_add_processed_at_to_teach_record_raw.sql
+++ b/sql/migrations/20241010_add_processed_at_to_teach_record_raw.sql
@@ -1,0 +1,5 @@
+ALTER TABLE teach_record_raw
+    ADD COLUMN processed_at DATETIME NULL DEFAULT NULL AFTER ingested_at;
+
+ALTER TABLE teach_record_raw
+    ADD KEY idx_teach_record_file_processed (file_hash, processed_at);

--- a/sql/migrations/20241011_nullify_zero_date_processed_at.sql
+++ b/sql/migrations/20241011_nullify_zero_date_processed_at.sql
@@ -1,0 +1,4 @@
+-- Normalize legacy processed_at values so the pipeline can resume batches.
+UPDATE `teach_record_raw`
+SET processed_at = NULL
+WHERE processed_at = '0000-00-00 00:00:00';

--- a/sql/migrations/20241012_update_teach_record_feedback_text.sql
+++ b/sql/migrations/20241012_update_teach_record_feedback_text.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `teach_record_raw`
+    MODIFY COLUMN `教學跟進/回饋` TEXT NULL;
+
+ALTER TABLE `teach_record_normalized`
+    MODIFY COLUMN `教學跟進/回饋` TEXT NULL;

--- a/sql/sheet_ingest_config.sql
+++ b/sql/sheet_ingest_config.sql
@@ -26,7 +26,7 @@ VALUES (
     'prototype_teaching_records',
     'TEACH_RECORD',
     'teach_record_raw',
-    JSON_ARRAY('id', 'file_hash', 'batch_id', 'source_year', 'ingested_at'),
+    JSON_ARRAY('id', 'file_hash', 'batch_id', 'source_year', 'ingested_at', 'processed_at'),
     JSON_ARRAY(
         '記錄狀態',
         '日期',

--- a/sql/sheet_ingest_config.sql
+++ b/sql/sheet_ingest_config.sql
@@ -89,7 +89,10 @@ VALUES (
         '備註', '備註',
         '教學跟進/回饋', '教學跟進/回饋'
     ),
-    JSON_OBJECT('rename_last_subject', true)
+    JSON_OBJECT(
+        'rename_last_subject', true,
+        'normalized_table', 'teach_record_normalized'
+    )
 )
 ON DUPLICATE KEY UPDATE
     staging_table = VALUES(staging_table),

--- a/sql/sheet_ingest_config.sql
+++ b/sql/sheet_ingest_config.sql
@@ -91,7 +91,8 @@ VALUES (
     ),
     JSON_OBJECT(
         'rename_last_subject', true,
-        'normalized_table', 'teach_record_normalized'
+        'normalized_table', 'teach_record_normalized',
+        'column_types', JSON_OBJECT('教學跟進/回饋', 'TEXT NULL')
     )
 )
 ON DUPLICATE KEY UPDATE

--- a/sql/teach_record_normalized.sql
+++ b/sql/teach_record_normalized.sql
@@ -33,7 +33,7 @@ CREATE TABLE `teach_record_normalized` (
   `練習` VARCHAR(255) NULL,
   `上課時數` DECIMAL(6,2) NULL,
   `備註` VARCHAR(255) NULL,
-  `教學跟進/回饋` VARCHAR(255) NULL,
+  `教學跟進/回饋` TEXT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uniq_teach_record_normalized_raw` (`raw_id`),
   KEY `idx_teach_record_normalized_file_hash` (`file_hash`)

--- a/sql/teaching_record_raw.sql
+++ b/sql/teaching_record_raw.sql
@@ -33,5 +33,7 @@ CREATE TABLE `teach_record_raw` (
   `batch_id` CHAR(36) NULL,
   `source_year` INT NULL,
   `ingested_at` DATETIME NOT NULL,
-  KEY idx_teach_record_file_hash (file_hash)
+  `processed_at` DATETIME NULL DEFAULT NULL,
+  KEY idx_teach_record_file_hash (file_hash),
+  KEY idx_teach_record_file_processed (file_hash, processed_at)
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/sql/teaching_record_raw.sql
+++ b/sql/teaching_record_raw.sql
@@ -28,7 +28,7 @@ CREATE TABLE `teach_record_raw` (
   `練習` VARCHAR(100) NULL,
   `上課時數` VARCHAR(100) NULL,
   `備註` VARCHAR(100) NULL,
-  `教學跟進/回饋` VARCHAR(255) NULL,
+  `教學跟進/回饋` TEXT NULL,
   `file_hash` CHAR(64) NOT NULL,
   `batch_id` CHAR(36) NULL,
   `source_year` INT NULL,

--- a/tests/test_ingest_excel.py
+++ b/tests/test_ingest_excel.py
@@ -157,48 +157,24 @@ class IngestExcelTests(unittest.TestCase):
             ("abc", "12345678-1234-5678-1234-567812345678", "2024", self.now),
         )
 
-    def test_main_ignores_trailing_csv_columns(self):
+    def test_main_rejects_csv_with_extra_columns(self):
         schema_header = ["日期", "任教老師"]
         full_header = schema_header + ["Extra A", "Extra B"]
         csv_path = self._create_csv(full_header)
 
-        fake_cursor = _Cursor(rowcount=2, fetchone_results=[(1,)])
-        connection = _Connection(fake_cursor)
-
         with mock.patch.object(
             ingest_excel.prep_excel, "main", return_value=(csv_path, "abc")
-        ) as prep_main, mock.patch.object(
+        ), mock.patch.object(
             ingest_excel.prep_excel, "_get_table_config", return_value={"table": "teach_record_raw"}
-        ) as get_config, mock.patch.object(
+        ), mock.patch.object(
             ingest_excel.prep_excel, "get_schema_details", return_value={"order": schema_header}
-        ) as get_schema, mock.patch.object(
-            ingest_excel.pymysql, "connect", return_value=connection
+        ), mock.patch.object(
+            ingest_excel.pymysql, "connect"
         ) as connect:
-            ingest_excel.main("workbook.xlsx", source_year="2024", batch_id="batch-1")
+            with self.assertRaisesRegex(ValueError, "CSV header does not match"):
+                ingest_excel.main("workbook.xlsx", source_year="2024", batch_id="batch-1")
 
-        prep_main.assert_called_once()
-        get_config.assert_called_once()
-        get_schema.assert_called_once()
-        connect.assert_called_once()
-
-        self.assertTrue(connection.begun)
-        self.assertTrue(connection.committed)
-        self.assertFalse(connection.rolled_back)
-
-        self.assertEqual(len(fake_cursor.executed), 2)
-        query, params = fake_cursor.executed[1]
-        column_list = ", ".join(["`日期`", "`任教老師`", "@unused_0", "@unused_1"])
-        expected_query = (
-            "LOAD DATA LOCAL INFILE %s INTO TABLE `teach_record_raw` "
-            "FIELDS TERMINATED BY ',' ENCLOSED BY '\"' "
-            "LINES TERMINATED BY '\n' IGNORE 1 LINES "
-            f"({column_list}) "
-            "SET file_hash = %s, batch_id = %s, source_year = %s, ingested_at = %s"
-        )
-        self.assertEqual(query, expected_query)
-        self.assertEqual(params[0], csv_path)
-        self.assertEqual(params[1:4], ("abc", "batch-1", "2024"))
-        self.assertEqual(params[4], self.now)
+        connect.assert_not_called()
 
     def test_main_logs_rowcount_for_multi_row_csv(self):
         header = ["日期", "任教老師"]

--- a/tests/test_normalize_staging.py
+++ b/tests/test_normalize_staging.py
@@ -170,7 +170,7 @@ def test_mark_staging_rows_processed_updates_by_file_hash(monkeypatch):
     assert cursor.execute_calls == [
         (
             "UPDATE `teach_record_raw` SET processed_at = %s "
-            "WHERE file_hash = %s AND processed_at IS NULL",
+            "WHERE file_hash = %s AND (processed_at IS NULL OR processed_at = '0000-00-00 00:00:00')",
             (processed_at, "hash-123"),
         )
     ]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -227,7 +227,7 @@ def test_run_pipeline_falls_back_when_config_lacks_column_mappings(
         {
             "sheet_name": "TEACH_RECORD",
             "staging_table": "teach_record_raw",
-            "metadata_columns": ["file_hash"],
+            "metadata_columns": ["file_hash", "processed_at"],
             "required_columns": [],
             "options": {"normalized_table": "teach_record_normalized"},
         }
@@ -307,7 +307,7 @@ def test_run_pipeline_uses_derived_normalized_table(monkeypatch):
         {
             "sheet_name": "TEACH_RECORD",
             "staging_table": "teach_record_raw",
-            "metadata_columns": ["file_hash"],
+            "metadata_columns": ["file_hash", "processed_at"],
             "required_columns": [],
             "options": {},
             "column_mappings": None,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+
+from app import ingest_excel, pipeline
+
+
+class _Cursor:
+    def __init__(self, rows):
+        self.rows = rows
+        self.executed = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self.rows
+
+
+class _Connection:
+    def __init__(self, rows):
+        self._rows = rows
+        self.cursor_calls = []
+        self.begun = False
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def cursor(self, cursor_class=None):
+        self.cursor_calls.append(cursor_class)
+        return _Cursor(self._rows)
+
+    def begin(self):
+        self.begun = True
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        self.closed = True
+
+
+def test_run_pipeline_threads_file_hash(monkeypatch):
+    csv_path = "/tmp/fake.csv"
+    file_hash = "hash-123"
+    staged_rows = [
+        {
+            "id": 1,
+            "file_hash": file_hash,
+            "batch_id": "batch-1",
+            "source_year": "2024",
+        },
+        {
+            "id": 2,
+            "file_hash": file_hash,
+            "batch_id": "batch-1",
+            "source_year": "2024",
+        },
+    ]
+    staging_result = ingest_excel.StagingLoadResult(
+        staging_table="teach_record_raw",
+        file_hash=file_hash,
+        batch_id="batch-1",
+        source_year="2024",
+        ingested_at=dt.datetime(2024, 5, 1, 12, 0, tzinfo=dt.timezone.utc),
+        rowcount=len(staged_rows),
+    )
+
+    captured = SimpleNamespace(prep_call=None, mark_call=None)
+
+    def fake_prep_main(workbook, sheet, *, emit_stdout, db_settings):
+        captured.prep_call = {
+            "workbook": workbook,
+            "sheet": sheet,
+            "emit_stdout": emit_stdout,
+            "db_settings": db_settings,
+        }
+        return csv_path, file_hash
+
+    monkeypatch.setattr(pipeline.prep_excel, "main", fake_prep_main)
+    monkeypatch.setattr(
+        pipeline.ingest_excel,
+        "load_csv_into_staging",
+        lambda *args, **kwargs: staging_result,
+    )
+    monkeypatch.setattr(
+        pipeline.prep_excel,
+        "_get_table_config",
+        lambda sheet, db_settings=None: {
+            "table": "teach_record_raw",
+            "normalized_table": "teach_record_normalized",
+            "column_mappings": {"姓名": "姓名"},
+        },
+    )
+
+    connection = _Connection(staged_rows)
+    monkeypatch.setattr(pipeline.pymysql, "connect", lambda **kwargs: connection)
+
+    inserted = {}
+
+    def fake_insert(connection_obj, table, rows, column_mappings):
+        inserted["table"] = table
+        inserted["rows"] = rows
+        inserted["column_mappings"] = column_mappings
+        return len(rows)
+
+    monkeypatch.setattr(
+        pipeline.normalize_staging,
+        "insert_normalized_rows",
+        fake_insert,
+    )
+
+    def fake_mark(connection_obj, table, row_ids, *, file_hash):
+        captured.mark_call = {
+            "table": table,
+            "row_ids": tuple(row_ids),
+            "file_hash": file_hash,
+        }
+        return dt.datetime(2024, 5, 1, 12, 30, tzinfo=dt.timezone.utc)
+
+    monkeypatch.setattr(
+        pipeline.normalize_staging,
+        "mark_staging_rows_processed",
+        fake_mark,
+    )
+
+    result = pipeline.run_pipeline(
+        "workbook.xlsx", source_year="2024", batch_id="batch-1"
+    )
+
+    assert captured.prep_call["emit_stdout"] is False
+    assert captured.prep_call["workbook"] == "workbook.xlsx"
+    assert inserted["table"] == "teach_record_normalized"
+    assert inserted["column_mappings"] == {"姓名": "姓名"}
+    assert captured.mark_call["file_hash"] == file_hash
+    assert captured.mark_call["row_ids"] == (1, 2)
+    assert result.file_hash == file_hash
+    assert result.staged_rows == len(staged_rows)
+    assert result.normalized_rows == len(staged_rows)
+    assert result.batch_id == "batch-1"
+    assert result.staging_table == "teach_record_raw"
+    assert result.normalized_table == "teach_record_normalized"
+    assert not result.skipped
+    assert connection.committed
+    assert not connection.rolled_back
+    assert connection.closed
+
+
+def test_cli_invokes_pipeline(monkeypatch, capsys):
+    result = pipeline.PipelineResult(
+        file_hash="hash-xyz",
+        staging_table="teach_record_raw",
+        normalized_table="teach_record_normalized",
+        staged_rows=2,
+        normalized_rows=2,
+        batch_id="batch-9",
+        ingested_at=dt.datetime(2024, 5, 1, tzinfo=dt.timezone.utc),
+        processed_at=dt.datetime(2024, 5, 1, 12, tzinfo=dt.timezone.utc),
+    )
+
+    captured_args = {}
+
+    def fake_run(workbook, sheet, *, source_year, batch_id, db_settings=None):
+        captured_args.update(
+            {
+                "workbook": workbook,
+                "sheet": sheet,
+                "source_year": source_year,
+                "batch_id": batch_id,
+                "db_settings": db_settings,
+            }
+        )
+        return result
+
+    monkeypatch.setattr(pipeline, "run_pipeline", fake_run)
+
+    returned = pipeline.cli(
+        ["workbook.xlsx", "SheetA", "--source-year", "2024", "--batch-id", "batch-9"]
+    )
+
+    out = capsys.readouterr().out
+    assert "Staged" in out
+    assert captured_args == {
+        "workbook": "workbook.xlsx",
+        "sheet": "SheetA",
+        "source_year": "2024",
+        "batch_id": "batch-9",
+        "db_settings": None,
+    }
+    assert returned is result
+

--- a/tests/test_prep_excel.py
+++ b/tests/test_prep_excel.py
@@ -215,6 +215,24 @@ class PrepExcelSchemaTests(unittest.TestCase):
 
         self.assertEqual(config["normalized_table"], "teach_record_normalized")
 
+    def test_sheet_config_derives_normalized_table_when_missing(self):
+        row = {
+            "sheet_name": prep_excel.DEFAULT_SHEET,
+            "staging_table": "teach_record_raw",
+            "metadata_columns": json.dumps(["id", "file_hash"]),
+            "required_columns": json.dumps([]),
+            "options": json.dumps({}),
+            "column_mappings": None,
+        }
+
+        connection = _FakeConnection([row])
+
+        config = prep_excel._get_table_config(
+            prep_excel.DEFAULT_SHEET, connection=connection
+        )
+
+        self.assertEqual(config["normalized_table"], "teach_record_normalized")
+
     def test_get_schema_details_with_injected_connection(self):
         config_rows = [
             {

--- a/tests/test_prep_excel.py
+++ b/tests/test_prep_excel.py
@@ -143,11 +143,36 @@ class PrepExcelSchemaTests(unittest.TestCase):
             }
         ]
         rows = [
-            {"COLUMN_NAME": "id", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "日期", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "任教老師", "IS_NULLABLE": "YES", "COLUMN_DEFAULT": ""},
-            {"COLUMN_NAME": "file_hash", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "學生編號", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
+            {
+                "COLUMN_NAME": "id",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "int(11)",
+            },
+            {
+                "COLUMN_NAME": "日期",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "date",
+            },
+            {
+                "COLUMN_NAME": "任教老師",
+                "IS_NULLABLE": "YES",
+                "COLUMN_DEFAULT": "",
+                "COLUMN_TYPE": "varchar(255)",
+            },
+            {
+                "COLUMN_NAME": "file_hash",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "varchar(64)",
+            },
+            {
+                "COLUMN_NAME": "學生編號",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "varchar(32)",
+            },
         ]
 
         config_connection = _FakeConnection(config_rows)
@@ -203,10 +228,30 @@ class PrepExcelSchemaTests(unittest.TestCase):
             }
         ]
         rows = [
-            {"COLUMN_NAME": "id", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "日期", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "任教老師", "IS_NULLABLE": "YES", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "file_hash", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
+            {
+                "COLUMN_NAME": "id",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "int(11)",
+            },
+            {
+                "COLUMN_NAME": "日期",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "date",
+            },
+            {
+                "COLUMN_NAME": "任教老師",
+                "IS_NULLABLE": "YES",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "varchar(255)",
+            },
+            {
+                "COLUMN_NAME": "file_hash",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "varchar(64)",
+            },
         ]
 
         config_connection = _FakeConnection(config_rows)
@@ -280,10 +325,30 @@ class PrepExcelSchemaTests(unittest.TestCase):
             }
         ]
         column_rows = [
-            {"COLUMN_NAME": "id", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "日期", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "任教老師", "IS_NULLABLE": "YES", "COLUMN_DEFAULT": None},
-            {"COLUMN_NAME": "file_hash", "IS_NULLABLE": "NO", "COLUMN_DEFAULT": None},
+            {
+                "COLUMN_NAME": "id",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "int(11)",
+            },
+            {
+                "COLUMN_NAME": "日期",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "date",
+            },
+            {
+                "COLUMN_NAME": "任教老師",
+                "IS_NULLABLE": "YES",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "varchar(255)",
+            },
+            {
+                "COLUMN_NAME": "file_hash",
+                "IS_NULLABLE": "NO",
+                "COLUMN_DEFAULT": None,
+                "COLUMN_TYPE": "varchar(64)",
+            },
         ]
 
         connection = _SequenceConnection(
@@ -371,11 +436,26 @@ class PrepExcelSchemaTests(unittest.TestCase):
         mock_get_table_config.return_value = config
 
         existing = [
-            {"name": "日期", "is_nullable": True, "default": None},
-            {"name": "任教老師", "is_nullable": True, "default": None},
+            {
+                "name": "日期",
+                "is_nullable": True,
+                "default": None,
+                "type": "date",
+            },
+            {
+                "name": "任教老師",
+                "is_nullable": True,
+                "default": None,
+                "type": "varchar(255)",
+            },
         ]
         expanded = existing + [
-            {"name": "新欄位", "is_nullable": True, "default": None},
+            {
+                "name": "新欄位",
+                "is_nullable": True,
+                "default": None,
+                "type": "varchar(255)",
+            },
         ]
         mock_fetch_columns.side_effect = [existing, expanded]
 
@@ -438,10 +518,20 @@ class PrepExcelSchemaTests(unittest.TestCase):
         mock_get_table_config.return_value = config
 
         existing = [
-            {"name": "日期", "is_nullable": True, "default": None},
+            {
+                "name": "日期",
+                "is_nullable": True,
+                "default": None,
+                "type": "date",
+            },
         ]
         expanded = existing + [
-            {"name": "教學跟進/回饋", "is_nullable": True, "default": None},
+            {
+                "name": "教學跟進/回饋",
+                "is_nullable": True,
+                "default": None,
+                "type": "text",
+            },
         ]
         mock_fetch_columns.side_effect = [existing, expanded]
 
@@ -461,6 +551,143 @@ class PrepExcelSchemaTests(unittest.TestCase):
             "ALTER TABLE `teach_record_raw` ADD COLUMN `教學跟進/回饋` TEXT NULL",
             None,
         ) in connection.commands
+
+    @mock.patch.object(prep_excel, "_staging_file_hash_exists", return_value=False)
+    @mock.patch.object(prep_excel, "_get_table_config")
+    @mock.patch.object(prep_excel, "_fetch_table_columns")
+    @mock.patch("app.prep_excel.pd.read_excel")
+    def test_main_modifies_existing_staging_column_type_when_override_differs(
+        self,
+        mock_read_excel,
+        mock_fetch_columns,
+        mock_get_table_config,
+        _mock_hash_exists,
+    ):
+        df = pd.DataFrame(
+            {
+                "日期": ["2024-01-01"],
+                "教學跟進/回饋": ["feedback"],
+            }
+        )
+        mock_read_excel.return_value = df
+
+        config = {
+            "table": "teach_record_raw",
+            "metadata_columns": frozenset(
+                {"file_hash", "batch_id", "source_year", "ingested_at"}
+            ),
+            "options": {},
+            "column_types": {"教學跟進/回饋": "TEXT NULL"},
+        }
+        mock_get_table_config.return_value = config
+
+        existing = [
+            {
+                "name": "日期",
+                "is_nullable": True,
+                "default": None,
+                "type": "date",
+            },
+            {
+                "name": "教學跟進/回饋",
+                "is_nullable": True,
+                "default": None,
+                "type": "varchar(255)",
+            },
+        ]
+        refreshed = [
+            {
+                "name": "日期",
+                "is_nullable": True,
+                "default": None,
+                "type": "date",
+            },
+            {
+                "name": "教學跟進/回饋",
+                "is_nullable": True,
+                "default": None,
+                "type": "text",
+            },
+        ]
+        mock_fetch_columns.side_effect = [existing, refreshed]
+
+        connection = _AlteringConnection()
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp:
+            tmp.write(b"dummy")
+            excel_path = tmp.name
+
+        try:
+            with mock.patch("pandas.DataFrame.to_csv", return_value=None):
+                prep_excel.main(excel_path, connection=connection, emit_stdout=False)
+        finally:
+            os.remove(excel_path)
+
+        assert (
+            "ALTER TABLE `teach_record_raw` MODIFY COLUMN `教學跟進/回饋` TEXT NULL",
+            None,
+        ) in connection.commands
+        self.assertEqual(connection.commits, 1)
+
+    @mock.patch.object(prep_excel, "_staging_file_hash_exists", return_value=False)
+    @mock.patch.object(prep_excel, "_get_table_config")
+    @mock.patch.object(prep_excel, "_fetch_table_columns")
+    @mock.patch("app.prep_excel.pd.read_excel")
+    def test_main_skips_modify_when_staging_column_matches_override(
+        self,
+        mock_read_excel,
+        mock_fetch_columns,
+        mock_get_table_config,
+        _mock_hash_exists,
+    ):
+        df = pd.DataFrame(
+            {
+                "日期": ["2024-01-01"],
+                "教學跟進/回饋": ["feedback"],
+            }
+        )
+        mock_read_excel.return_value = df
+
+        config = {
+            "table": "teach_record_raw",
+            "metadata_columns": frozenset(
+                {"file_hash", "batch_id", "source_year", "ingested_at"}
+            ),
+            "options": {},
+            "column_types": {"教學跟進/回饋": "TEXT NULL"},
+        }
+        mock_get_table_config.return_value = config
+
+        existing = [
+            {
+                "name": "日期",
+                "is_nullable": True,
+                "default": None,
+                "type": "date",
+            },
+            {
+                "name": "教學跟進/回饋",
+                "is_nullable": True,
+                "default": None,
+                "type": "text",
+            },
+        ]
+        mock_fetch_columns.side_effect = [existing, existing]
+
+        connection = _AlteringConnection()
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp:
+            tmp.write(b"dummy")
+            excel_path = tmp.name
+
+        try:
+            with mock.patch("pandas.DataFrame.to_csv", return_value=None):
+                prep_excel.main(excel_path, connection=connection, emit_stdout=False)
+        finally:
+            os.remove(excel_path)
+
+        self.assertEqual(connection.commands, [])
+        self.assertEqual(connection.commits, 0)
 
     def test_staging_file_hash_exists_with_injected_connection(self):
         connection = _SequenceConnection([

--- a/tests/test_prep_excel.py
+++ b/tests/test_prep_excel.py
@@ -191,6 +191,30 @@ class PrepExcelSchemaTests(unittest.TestCase):
             },
         )
 
+    def test_sheet_config_prefers_row_with_normalized_table(self):
+        generic_row = {
+            "sheet_name": prep_excel.DEFAULT_SHEET,
+            "staging_table": "teach_record_raw",
+            "metadata_columns": json.dumps(["id", "file_hash"]),
+            "required_columns": json.dumps([]),
+            "options": json.dumps({}),
+        }
+        specific_row = {
+            "sheet_name": prep_excel.DEFAULT_SHEET,
+            "staging_table": "teach_record_raw",
+            "metadata_columns": json.dumps(["id", "file_hash"]),
+            "required_columns": json.dumps([]),
+            "options": json.dumps({"normalized_table": "teach_record_normalized"}),
+        }
+
+        connection = _FakeConnection([generic_row, specific_row])
+
+        config = prep_excel._get_table_config(
+            prep_excel.DEFAULT_SHEET, connection=connection
+        )
+
+        self.assertEqual(config["normalized_table"], "teach_record_normalized")
+
     def test_get_schema_details_with_injected_connection(self):
         config_rows = [
             {

--- a/tests/test_prep_excel.py
+++ b/tests/test_prep_excel.py
@@ -100,7 +100,14 @@ class PrepExcelSchemaTests(unittest.TestCase):
                 "sheet_name": prep_excel.DEFAULT_SHEET,
                 "staging_table": "teach_record_raw",
                 "metadata_columns": json.dumps(
-                    ["id", "file_hash", "batch_id", "source_year", "ingested_at"]
+                    [
+                        "id",
+                        "file_hash",
+                        "batch_id",
+                        "source_year",
+                        "ingested_at",
+                        "processed_at",
+                    ]
                 ),
                 "required_columns": json.dumps([]),
                 "options": None,
@@ -161,7 +168,7 @@ class PrepExcelSchemaTests(unittest.TestCase):
             {
                 "sheet_name": prep_excel.DEFAULT_SHEET,
                 "staging_table": "teach_record_raw",
-                "metadata_columns": json.dumps(["id", "file_hash"]),
+                "metadata_columns": json.dumps(["id", "file_hash", "processed_at"]),
                 "required_columns": json.dumps(["日期"]),
                 "options": None,
             }
@@ -195,14 +202,14 @@ class PrepExcelSchemaTests(unittest.TestCase):
         generic_row = {
             "sheet_name": prep_excel.DEFAULT_SHEET,
             "staging_table": "teach_record_raw",
-            "metadata_columns": json.dumps(["id", "file_hash"]),
+            "metadata_columns": json.dumps(["id", "file_hash", "processed_at"]),
             "required_columns": json.dumps([]),
             "options": json.dumps({}),
         }
         specific_row = {
             "sheet_name": prep_excel.DEFAULT_SHEET,
             "staging_table": "teach_record_raw",
-            "metadata_columns": json.dumps(["id", "file_hash"]),
+            "metadata_columns": json.dumps(["id", "file_hash", "processed_at"]),
             "required_columns": json.dumps([]),
             "options": json.dumps({"normalized_table": "teach_record_normalized"}),
         }
@@ -219,7 +226,7 @@ class PrepExcelSchemaTests(unittest.TestCase):
         row = {
             "sheet_name": prep_excel.DEFAULT_SHEET,
             "staging_table": "teach_record_raw",
-            "metadata_columns": json.dumps(["id", "file_hash"]),
+            "metadata_columns": json.dumps(["id", "file_hash", "processed_at"]),
             "required_columns": json.dumps([]),
             "options": json.dumps({}),
             "column_mappings": None,
@@ -238,7 +245,7 @@ class PrepExcelSchemaTests(unittest.TestCase):
             {
                 "sheet_name": prep_excel.DEFAULT_SHEET,
                 "staging_table": "teach_record_raw",
-                "metadata_columns": json.dumps(["id", "file_hash"]),
+                "metadata_columns": json.dumps(["id", "file_hash", "processed_at"]),
                 "required_columns": json.dumps([]),
                 "options": None,
             }


### PR DESCRIPTION
## Summary
- extract staging LOAD DATA logic into a reusable helper that returns metadata
- add an orchestration pipeline module with CLI support to run staging and normalization end to end
- cover the pipeline flow with new unit tests including CLI invocation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df2c488904832283c37690d440a223