### PR TITLE
Fix ingest loader definition

### DIFF
--- a/app/ingest_excel.py
+++ b/app/ingest_excel.py
@@ -111,11 +111,10 @@ def _quote_identifier(identifier: str) -> str:
     return "`" + identifier.replace("`", "``") + "`"
 
 
-def main(
-    workbook_path: str,
-    sheet: str = prep_excel.DEFAULT_SHEET,
+def load_csv_into_staging(
+    csv_path: str,
     *,
-    sheet: str,
+    sheet: str = prep_excel.DEFAULT_SHEET,
     workbook_type: str = "default",
     source_year: str,
     file_hash: str,


### PR DESCRIPTION
## Summary
- restore the ingest loader helper as load_csv_into_staging instead of a duplicated main definition
- ensure the helper accepts the csv_path parameter so staging loads reference the correct file

## Testing
- python -m app.pipeline uploads/SIMS04102M.xlsx_20250930_212332_014.xlsx --source-year 2526 --workbook-type teaching_records *(fails: Missing required database configuration environment variable(s): DB_HOST, DB_USER, DB_PASSWORD, DB_NAME, DB_CHARSET)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e83ff7848322b4106afd6c9da40e