### PR TITLE
Rewrite README to capture job tracking updates

### DIFF
--- a/app/job_store.py
+++ b/app/job_store.py
@@ -1,0 +1,341 @@
+"""Helpers for interacting with upload job tracking tables."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
+
+import pymysql
+from pymysql import err as pymysql_err
+
+from app.config import get_db_settings
+
+
+@dataclass(frozen=True)
+class UploadJob:
+    """Structured representation of a row in ``upload_jobs``."""
+
+    job_id: str
+    original_filename: str
+    workbook_name: str | None
+    worksheet_name: str | None
+    file_size: int | None
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class UploadJobEvent:
+    """Structured representation of a row in ``upload_job_events``."""
+
+    event_id: int
+    job_id: str
+    status: str
+    message: str | None
+    event_at: datetime
+
+
+@dataclass(frozen=True)
+class UploadJobResult:
+    """Structured representation of a row in ``upload_job_results``."""
+
+    job_id: str
+    total_rows: int | None
+    processed_rows: int | None
+    successful_rows: int | None
+    rejected_rows: int | None
+    normalized_table_name: str | None
+    rejected_rows_path: str | None
+    coverage_metadata: Any
+    created_at: datetime
+    updated_at: datetime
+
+
+def _connect(overrides: Mapping[str, Any] | None = None) -> pymysql.connections.Connection:
+    settings: dict[str, Any] = dict(get_db_settings())
+    if overrides:
+        settings.update(overrides)
+    return pymysql.connect(**settings)
+
+
+def _dict_to_upload_job(row: Mapping[str, Any] | None) -> UploadJob:
+    if row is None:
+        raise ValueError("Upload job not found")
+    return UploadJob(
+        job_id=row["job_id"],
+        original_filename=row["original_filename"],
+        workbook_name=row.get("workbook_name"),
+        worksheet_name=row.get("worksheet_name"),
+        file_size=row.get("file_size"),
+        status=row["status"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _dict_to_upload_job_event(row: Mapping[str, Any] | None) -> UploadJobEvent:
+    if row is None:
+        raise ValueError("Upload job event not found")
+    return UploadJobEvent(
+        event_id=row["event_id"],
+        job_id=row["job_id"],
+        status=row["status"],
+        message=row.get("message"),
+        event_at=row["event_at"],
+    )
+
+
+def _dict_to_upload_job_result(row: Mapping[str, Any] | None) -> UploadJobResult:
+    if row is None:
+        raise ValueError("Upload job results not found")
+    return UploadJobResult(
+        job_id=row["job_id"],
+        total_rows=row.get("total_rows"),
+        processed_rows=row.get("processed_rows"),
+        successful_rows=row.get("successful_rows"),
+        rejected_rows=row.get("rejected_rows"),
+        normalized_table_name=row.get("normalized_table_name"),
+        rejected_rows_path=row.get("rejected_rows_path"),
+        coverage_metadata=row.get("coverage_metadata"),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def create_job(
+    *,
+    original_filename: str,
+    status: str,
+    job_id: str | None = None,
+    workbook_name: str | None = None,
+    worksheet_name: str | None = None,
+    file_size: int | None = None,
+    status_message: str | None = None,
+    db_settings: Mapping[str, Any] | None = None,
+) -> UploadJob:
+    """Create a new upload job and optionally log its first status event."""
+
+    job_id = job_id or str(uuid.uuid4())
+    connection = _connect(db_settings)
+    try:
+        connection.begin()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    (
+                        "INSERT INTO `upload_jobs` "
+                        "(job_id, original_filename, workbook_name, worksheet_name, file_size, status) "
+                        "VALUES (%s, %s, %s, %s, %s, %s)"
+                    ),
+                    (
+                        job_id,
+                        original_filename,
+                        workbook_name,
+                        worksheet_name,
+                        file_size,
+                        status,
+                    ),
+                )
+                if status_message is not None:
+                    cursor.execute(
+                        (
+                            "INSERT INTO `upload_job_events` (job_id, status, message) "
+                            "VALUES (%s, %s, %s)"
+                        ),
+                        (job_id, status, status_message),
+                    )
+            with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+                cursor.execute(
+                    "SELECT * FROM `upload_jobs` WHERE job_id = %s",
+                    (job_id,),
+                )
+                job_row = cursor.fetchone()
+            connection.commit()
+        except pymysql_err.IntegrityError as exc:
+            connection.rollback()
+            raise ValueError(f"Failed to create upload job: {exc.args[1] if len(exc.args) > 1 else exc}") from exc
+        except Exception:
+            connection.rollback()
+            raise
+    finally:
+        connection.close()
+
+    return _dict_to_upload_job(job_row)
+
+
+def set_status(
+    job_id: str,
+    status: str,
+    *,
+    message: str | None = None,
+    db_settings: Mapping[str, Any] | None = None,
+) -> tuple[UploadJob, UploadJobEvent]:
+    """Update the job status and record a corresponding event."""
+
+    connection = _connect(db_settings)
+    try:
+        connection.begin()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "UPDATE `upload_jobs` SET status = %s WHERE job_id = %s",
+                    (status, job_id),
+                )
+                if cursor.rowcount == 0:
+                    raise ValueError(f"Upload job {job_id} does not exist")
+                cursor.execute(
+                    (
+                        "INSERT INTO `upload_job_events` (job_id, status, message) "
+                        "VALUES (%s, %s, %s)"
+                    ),
+                    (job_id, status, message),
+                )
+                event_id = cursor.lastrowid
+            with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+                cursor.execute(
+                    "SELECT * FROM `upload_jobs` WHERE job_id = %s",
+                    (job_id,),
+                )
+                job_row = cursor.fetchone()
+                cursor.execute(
+                    "SELECT * FROM `upload_job_events` WHERE event_id = %s",
+                    (event_id,),
+                )
+                event_row = cursor.fetchone()
+            connection.commit()
+        except pymysql_err.IntegrityError as exc:
+            connection.rollback()
+            raise ValueError(
+                f"Failed to update status for upload job {job_id}: "
+                f"{exc.args[1] if len(exc.args) > 1 else exc}"
+            ) from exc
+        except Exception:
+            connection.rollback()
+            raise
+    finally:
+        connection.close()
+
+    return _dict_to_upload_job(job_row), _dict_to_upload_job_event(event_row)
+
+
+def record_results(
+    job_id: str,
+    *,
+    total_rows: int | None = None,
+    processed_rows: int | None = None,
+    successful_rows: int | None = None,
+    rejected_rows: int | None = None,
+    normalized_table_name: str | None = None,
+    coverage_metadata: Any = None,
+    db_settings: Mapping[str, Any] | None = None,
+) -> UploadJobResult:
+    """Insert or update upload job results and return the stored record."""
+
+    columns: list[str] = []
+    values: list[Any] = []
+    updates: list[str] = []
+    field_map = {
+        "total_rows": total_rows,
+        "processed_rows": processed_rows,
+        "successful_rows": successful_rows,
+        "rejected_rows": rejected_rows,
+        "normalized_table_name": normalized_table_name,
+        "coverage_metadata": json.dumps(coverage_metadata)
+        if isinstance(coverage_metadata, (dict, list))
+        else coverage_metadata,
+    }
+
+    for column, value in field_map.items():
+        columns.append(f"`{column}`")
+        values.append(value)
+        updates.append(f"`{column}` = VALUES(`{column}`)")
+
+    placeholders = ", ".join(["%s"] * len(columns))
+    column_list = ", ".join(columns)
+    update_clause = ", ".join(updates) + ", `updated_at` = CURRENT_TIMESTAMP"
+
+    connection = _connect(db_settings)
+    try:
+        connection.begin()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    (
+                        "INSERT INTO `upload_job_results` (job_id, {columns}) "
+                        "VALUES (%s, {placeholders}) "
+                        "ON DUPLICATE KEY UPDATE {updates}"
+                    ).format(columns=column_list, placeholders=placeholders, updates=update_clause),
+                    [job_id, *values],
+                )
+            with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+                cursor.execute(
+                    "SELECT * FROM `upload_job_results` WHERE job_id = %s",
+                    (job_id,),
+                )
+                result_row = cursor.fetchone()
+            connection.commit()
+        except pymysql_err.IntegrityError as exc:
+            connection.rollback()
+            raise ValueError(
+                f"Failed to record results for upload job {job_id}: "
+                f"{exc.args[1] if len(exc.args) > 1 else exc}"
+            ) from exc
+        except Exception:
+            connection.rollback()
+            raise
+    finally:
+        connection.close()
+
+    return _dict_to_upload_job_result(result_row)
+
+
+def save_rejected_rows_path(
+    job_id: str,
+    rejected_rows_path: str | None,
+    *,
+    db_settings: Mapping[str, Any] | None = None,
+) -> UploadJobResult:
+    """Persist the rejected rows path for an upload job."""
+
+    connection = _connect(db_settings)
+    try:
+        connection.begin()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    (
+                        "UPDATE `upload_job_results` "
+                        "SET rejected_rows_path = %s, updated_at = CURRENT_TIMESTAMP "
+                        "WHERE job_id = %s"
+                    ),
+                    (rejected_rows_path, job_id),
+                )
+                if cursor.rowcount == 0:
+                    raise ValueError(
+                        "Cannot save rejected rows path before recording results"
+                    )
+            with connection.cursor(pymysql.cursors.DictCursor) as cursor:
+                cursor.execute(
+                    "SELECT * FROM `upload_job_results` WHERE job_id = %s",
+                    (job_id,),
+                )
+                result_row = cursor.fetchone()
+            connection.commit()
+        except pymysql_err.IntegrityError as exc:
+            connection.rollback()
+            raise ValueError(
+                f"Failed to save rejected rows path for upload job {job_id}: "
+                f"{exc.args[1] if len(exc.args) > 1 else exc}"
+            ) from exc
+        except Exception:
+            connection.rollback()
+            raise
+    finally:
+        connection.close()
+
+    return _dict_to_upload_job_result(result_row)
+

--- a/sql/migrations/20241013_create_upload_job_tables.sql
+++ b/sql/migrations/20241013_create_upload_job_tables.sql
@@ -1,0 +1,40 @@
+CREATE TABLE `upload_jobs` (
+    `job_id` CHAR(36) NOT NULL,
+    `original_filename` VARCHAR(255) NOT NULL,
+    `workbook_name` VARCHAR(255) NULL,
+    `worksheet_name` VARCHAR(255) NULL,
+    `file_size` BIGINT UNSIGNED NULL,
+    `status` VARCHAR(64) NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`job_id`),
+    KEY `idx_upload_jobs_status_created_at` (`status`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `upload_job_events` (
+    `event_id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `job_id` CHAR(36) NOT NULL,
+    `status` VARCHAR(64) NOT NULL,
+    `message` TEXT NULL,
+    `event_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`event_id`),
+    KEY `idx_upload_job_events_job_id` (`job_id`),
+    KEY `idx_upload_job_events_status_event_at` (`status`, `event_at`),
+    CONSTRAINT `fk_upload_job_events_job` FOREIGN KEY (`job_id`) REFERENCES `upload_jobs` (`job_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `upload_job_results` (
+    `job_id` CHAR(36) NOT NULL,
+    `total_rows` INT UNSIGNED NULL,
+    `processed_rows` INT UNSIGNED NULL,
+    `successful_rows` INT UNSIGNED NULL,
+    `rejected_rows` INT UNSIGNED NULL,
+    `normalized_table_name` VARCHAR(255) NULL,
+    `rejected_rows_path` VARCHAR(512) NULL,
+    `coverage_metadata` JSON NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`job_id`),
+    KEY `idx_upload_job_results_normalized_table_name` (`normalized_table_name`),
+    CONSTRAINT `fk_upload_job_results_job` FOREIGN KEY (`job_id`) REFERENCES `upload_jobs` (`job_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -1,0 +1,352 @@
+import json
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+from app import job_store
+
+
+class CursorStub:
+    def __init__(
+        self,
+        executed,
+        *,
+        rowcount=1,
+        fetchone_results=None,
+        lastrowid=0,
+        exception=None,
+    ):
+        self.executed = executed
+        self.rowcount = rowcount
+        self.lastrowid = lastrowid
+        self._fetchone_results = list(fetchone_results or [])
+        self._exception = exception
+
+    def __enter__(self):
+        if self._exception:
+            raise self._exception
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, query, params=None):
+        if self._exception:
+            raise self._exception
+        self.executed.append((query, tuple(params or ())))
+
+    def fetchone(self):
+        if self._exception:
+            raise self._exception
+        if self._fetchone_results:
+            return self._fetchone_results.pop(0)
+        return None
+
+
+class ConnectionStub:
+    def __init__(self, cursors):
+        self._cursors = {key: list(value) for key, value in cursors.items()}
+        self.begun = False
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def cursor(self, cursor_class=None):
+        key = cursor_class
+        cursor_list = self._cursors.get(key)
+        if not cursor_list:
+            raise AssertionError(f"No cursor prepared for {cursor_class!r}")
+        return cursor_list.pop(0)
+
+    def begin(self):
+        self.begun = True
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def patch_db_settings(monkeypatch):
+    monkeypatch.setattr(job_store, "get_db_settings", lambda: {})
+
+
+def _set_connection(monkeypatch, connection):
+    monkeypatch.setattr(job_store, "_connect", lambda overrides=None: connection)
+
+
+def test_create_job_inserts_and_returns_job(monkeypatch):
+    job_id = "12345678-1234-5678-1234-567812345678"
+    executed_default = []
+    executed_dict = []
+    job_row = {
+        "job_id": job_id,
+        "original_filename": "file.csv",
+        "workbook_name": None,
+        "worksheet_name": None,
+        "file_size": None,
+        "status": "pending",
+        "created_at": datetime(2024, 1, 1, 12, 0, 0),
+        "updated_at": datetime(2024, 1, 1, 12, 5, 0),
+    }
+    connection = ConnectionStub(
+        {
+            None: [CursorStub(executed_default)],
+            job_store.pymysql.cursors.DictCursor: [CursorStub(executed_dict, fetchone_results=[job_row])],
+        }
+    )
+    _set_connection(monkeypatch, connection)
+    monkeypatch.setattr(job_store.uuid, "uuid4", lambda: job_id)
+
+    result = job_store.create_job(
+        original_filename="file.csv",
+        status="pending",
+        status_message="queued",
+    )
+
+    assert connection.begun is True
+    assert connection.committed is True
+    assert connection.rolled_back is False
+    assert connection.closed is True
+
+    assert executed_default == [
+        (
+            "INSERT INTO `upload_jobs` (job_id, original_filename, workbook_name, worksheet_name, file_size, status) VALUES (%s, %s, %s, %s, %s, %s)",
+            (job_id, "file.csv", None, None, None, "pending"),
+        ),
+        (
+            "INSERT INTO `upload_job_events` (job_id, status, message) VALUES (%s, %s, %s)",
+            (job_id, "pending", "queued"),
+        ),
+    ]
+    assert executed_dict == [
+        ("SELECT * FROM `upload_jobs` WHERE job_id = %s", (job_id,)),
+    ]
+    assert result == job_store.UploadJob(**job_row)
+
+
+def test_create_job_duplicate_rolls_back(monkeypatch):
+    executed_default = []
+    integrity_error = job_store.pymysql_err.IntegrityError(1062, "Duplicate entry")
+    connection = ConnectionStub({None: [CursorStub(executed_default, exception=integrity_error)]})
+    _set_connection(monkeypatch, connection)
+
+    with pytest.raises(ValueError) as excinfo:
+        job_store.create_job(original_filename="file.csv", status="pending")
+
+    assert "Failed to create upload job" in str(excinfo.value)
+    assert connection.committed is False
+    assert connection.rolled_back is True
+    assert executed_default == []
+
+
+def test_set_status_updates_and_logs_event(monkeypatch):
+    job_id = "abc"
+    executed_default = []
+    executed_dict = []
+    job_row = {
+        "job_id": job_id,
+        "original_filename": "file.csv",
+        "workbook_name": None,
+        "worksheet_name": None,
+        "file_size": None,
+        "status": "done",
+        "created_at": datetime(2024, 1, 1, 12, 0, 0),
+        "updated_at": datetime(2024, 1, 1, 12, 10, 0),
+    }
+    event_row = {
+        "event_id": 5,
+        "job_id": job_id,
+        "status": "done",
+        "message": "complete",
+        "event_at": datetime(2024, 1, 1, 12, 10, 0),
+    }
+    connection = ConnectionStub(
+        {
+            None: [CursorStub(executed_default, rowcount=1, lastrowid=5)],
+            job_store.pymysql.cursors.DictCursor: [
+                CursorStub(executed_dict, fetchone_results=[job_row, event_row])
+            ],
+        }
+    )
+    _set_connection(monkeypatch, connection)
+
+    job, event = job_store.set_status(job_id, "done", message="complete")
+
+    assert executed_default == [
+        ("UPDATE `upload_jobs` SET status = %s WHERE job_id = %s", ("done", job_id)),
+        (
+            "INSERT INTO `upload_job_events` (job_id, status, message) VALUES (%s, %s, %s)",
+            (job_id, "done", "complete"),
+        ),
+    ]
+    assert executed_dict == [
+        ("SELECT * FROM `upload_jobs` WHERE job_id = %s", (job_id,)),
+        ("SELECT * FROM `upload_job_events` WHERE event_id = %s", (5,)),
+    ]
+    assert job == job_store.UploadJob(**job_row)
+    assert event == job_store.UploadJobEvent(**event_row)
+    assert connection.committed is True
+    assert connection.rolled_back is False
+
+
+def test_set_status_missing_job_rolls_back(monkeypatch):
+    executed_default = []
+    connection = ConnectionStub({None: [CursorStub(executed_default, rowcount=0)]})
+    _set_connection(monkeypatch, connection)
+
+    with pytest.raises(ValueError) as excinfo:
+        job_store.set_status("missing", "done")
+
+    assert "does not exist" in str(excinfo.value)
+    assert executed_default == [
+        ("UPDATE `upload_jobs` SET status = %s WHERE job_id = %s", ("done", "missing")),
+    ]
+    assert connection.committed is False
+    assert connection.rolled_back is True
+
+
+def test_record_results_upserts_and_serializes(monkeypatch):
+    job_id = "job"
+    executed_default = []
+    executed_dict = []
+    result_row = {
+        "job_id": job_id,
+        "total_rows": 10,
+        "processed_rows": 9,
+        "successful_rows": 8,
+        "rejected_rows": 1,
+        "normalized_table_name": "table",
+        "rejected_rows_path": "path.csv",
+        "coverage_metadata": {"a": 1},
+        "created_at": datetime(2024, 1, 1, 12, 0, 0),
+        "updated_at": datetime(2024, 1, 1, 12, 5, 0),
+    }
+    connection = ConnectionStub(
+        {
+            None: [CursorStub(executed_default)],
+            job_store.pymysql.cursors.DictCursor: [CursorStub(executed_dict, fetchone_results=[result_row])],
+        }
+    )
+    _set_connection(monkeypatch, connection)
+
+    result = job_store.record_results(
+        job_id,
+        total_rows=10,
+        processed_rows=9,
+        successful_rows=8,
+        rejected_rows=1,
+        normalized_table_name="table",
+        coverage_metadata={"a": 1},
+    )
+
+    expected_query = (
+        "INSERT INTO `upload_job_results` (job_id, `total_rows`, `processed_rows`, `successful_rows`, "
+        "`rejected_rows`, `normalized_table_name`, `coverage_metadata`) VALUES (%s, %s, %s, %s, %s, %s, %s) "
+        "ON DUPLICATE KEY UPDATE `total_rows` = VALUES(`total_rows`), `processed_rows` = VALUES(`processed_rows`), "
+        "`successful_rows` = VALUES(`successful_rows`), `rejected_rows` = VALUES(`rejected_rows`), "
+        "`normalized_table_name` = VALUES(`normalized_table_name`), `coverage_metadata` = VALUES(`coverage_metadata`), "
+        "`updated_at` = CURRENT_TIMESTAMP"
+    )
+    assert executed_default == [
+        (
+            expected_query,
+            (
+                job_id,
+                10,
+                9,
+                8,
+                1,
+                "table",
+                json.dumps({"a": 1}),
+            ),
+        )
+    ]
+    assert executed_dict == [
+        ("SELECT * FROM `upload_job_results` WHERE job_id = %s", (job_id,)),
+    ]
+    assert result == job_store.UploadJobResult(**result_row)
+    assert connection.committed is True
+    assert connection.rolled_back is False
+
+
+def test_record_results_integrity_error(monkeypatch):
+    executed_default = []
+    integrity_error = job_store.pymysql_err.IntegrityError(1062, "Duplicate entry")
+    connection = ConnectionStub({None: [CursorStub(executed_default, exception=integrity_error)]})
+    _set_connection(monkeypatch, connection)
+
+    with pytest.raises(ValueError) as excinfo:
+        job_store.record_results("job")
+
+    assert "Failed to record results" in str(excinfo.value)
+    assert connection.committed is False
+    assert connection.rolled_back is True
+
+
+def test_save_rejected_rows_path_updates(monkeypatch):
+    job_id = "job"
+    executed_default = []
+    executed_dict = []
+    result_row = {
+        "job_id": job_id,
+        "total_rows": None,
+        "processed_rows": None,
+        "successful_rows": None,
+        "rejected_rows": None,
+        "normalized_table_name": None,
+        "rejected_rows_path": "rejected.csv",
+        "coverage_metadata": None,
+        "created_at": datetime(2024, 1, 1, 12, 0, 0),
+        "updated_at": datetime(2024, 1, 1, 12, 5, 0),
+    }
+    connection = ConnectionStub(
+        {
+            None: [CursorStub(executed_default, rowcount=1)],
+            job_store.pymysql.cursors.DictCursor: [CursorStub(executed_dict, fetchone_results=[result_row])],
+        }
+    )
+    _set_connection(monkeypatch, connection)
+
+    result = job_store.save_rejected_rows_path(job_id, "rejected.csv")
+
+    assert executed_default == [
+        (
+            "UPDATE `upload_job_results` SET rejected_rows_path = %s, updated_at = CURRENT_TIMESTAMP WHERE job_id = %s",
+            ("rejected.csv", job_id),
+        )
+    ]
+    assert executed_dict == [
+        ("SELECT * FROM `upload_job_results` WHERE job_id = %s", (job_id,)),
+    ]
+    assert result == job_store.UploadJobResult(**result_row)
+    assert connection.committed is True
+    assert connection.rolled_back is False
+
+
+def test_save_rejected_rows_path_without_results(monkeypatch):
+    executed_default = []
+    connection = ConnectionStub({None: [CursorStub(executed_default, rowcount=0)]})
+    _set_connection(monkeypatch, connection)
+
+    with pytest.raises(ValueError) as excinfo:
+        job_store.save_rejected_rows_path("job", "rejected.csv")
+
+    assert "Cannot save rejected rows path" in str(excinfo.value)
+    assert executed_default == [
+        (
+            "UPDATE `upload_job_results` SET rejected_rows_path = %s, updated_at = CURRENT_TIMESTAMP WHERE job_id = %s",
+            ("rejected.csv", "job"),
+        )
+    ]
+    assert connection.committed is False
+    assert connection.rolled_back is True


### PR DESCRIPTION
## Summary
- rewrite the README to describe the ingestion workflow, job-store helpers, and new migration sequence
- document current capabilities, operational guidance, and an expanded roadmap for upcoming work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e26801b5148322bc655552f671c831